### PR TITLE
Loop break op

### DIFF
--- a/control_flow/__main__.py
+++ b/control_flow/__main__.py
@@ -18,7 +18,8 @@ def doit(fn, name=None):
         name = fn.__name__
     print(name)
 
-    bb_mgr = basic_blocks(fn)
+    offset2inst_index = {}
+    bb_mgr = basic_blocks(fn, offset2inst_index)
     # for bb in bb_mgr.bb_list:
     #     print("\t", bb)
     dis.dis(fn)
@@ -40,7 +41,7 @@ def doit(fn, name=None):
         write_dot(name, "/tmp/flow-pdom-", cfg.pdom_tree, write_png=True)
 
         print("=" * 30)
-        augmented_instrs = augment_instructions(fn, cfg, opc.version_tuple)
+        augmented_instrs = augment_instructions(fn, cfg, opc, offset2inst_index, bb_mgr)
         for inst in augmented_instrs:
             print(inst.disassemble(opc))
         # return cs_str

--- a/control_flow/dominators.py
+++ b/control_flow/dominators.py
@@ -12,6 +12,12 @@ from control_flow.graph import TreeGraph
 from control_flow.traversals import dfs_postorder_nodes
 
 
+class DominatorSet(set):
+    def __str__(self) -> str:
+        sorted_set = {dom.bb.number for dom in sorted(self)}
+        return f"DominatorSet<{sorted_set}>"
+
+
 class DominatorTree(object):
     """
     Handles the dominator trees (dominator/post-dominator), and the
@@ -166,7 +172,7 @@ class DominatorTree(object):
 
 def build_dom_set(t, do_pdoms):
     """Makes a the dominator set for each node in the tree"""
-    seen = set()
+    seen = DominatorSet()
     for node in t.nodes:
         if node not in seen:
             seen.add(node)
@@ -179,9 +185,9 @@ def build_dom_set1(node, do_pdoms):
     """Build dominator sets from dominator node"""
 
     if do_pdoms:
-        node.bb.pdom_set = set(node.bb.pdoms)
+        node.bb.pdom_set = DominatorSet(node.bb.pdoms)
     else:
-        node.bb.dom_set = set(node.bb.doms)
+        node.bb.dom_set = DominatorSet(node.bb.doms)
         pass
 
     for child in node.children:
@@ -203,9 +209,9 @@ def dfs_forest(t, do_pdoms):
             return
         seen.add(node)
         if do_pdoms:
-            node.bb.pdoms = node.pdoms = set([node])
+            node.bb.pdoms = node.pdoms = DominatorSet([node])
         else:
-            node.bb.doms = node.doms = set([node])
+            node.bb.doms = node.doms = DominatorSet([node])
             node.bb.reach_offset = node.reach_offset = node.bb.end_offset
 
         for n in node.children:

--- a/control_flow/graph.py
+++ b/control_flow/graph.py
@@ -150,14 +150,17 @@ class Node(object):
     def reset(self):
         self.GLOBAL_COUNTER = 0
 
-    def __ne__(self, obj):
-        return not self == obj
-
-    def __eq__(self, obj):
+    def __eq__(self, obj) -> bool:
         return isinstance(obj, Node) and obj.number == self.number
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash("node-" + str(self.number))
+
+    def __lt__(self, obj) -> bool:
+        return not self.number < obj.number
+
+    def __ne__(self, obj):
+        return not self == obj
 
     def __repr__(self):
         return "Node%d(flags=%s, bb=%s)" % (

--- a/pytest/test_bb.py
+++ b/pytest/test_bb.py
@@ -33,12 +33,13 @@ def check_blocks(bb_list: list):
 
 def test_basic():
 
+    offset2inst_index = {}
     for fn in (two_basic_blocks, if_else_blocks):
         if debug:
             print(fn.__name__)
             dis.dis(fn)
             print()
-        bb_mgr = basic_blocks(fn)
+        bb_mgr = basic_blocks(fn, offset2inst_index)
         check_blocks(bb_mgr.bb_list)
 
 

--- a/pytest/test_cfg.py
+++ b/pytest/test_cfg.py
@@ -50,12 +50,13 @@ def check_cfg(fn: Callable, cfg: ControlFlowGraph):
 
 
 def test_basic():
+    offset2inst_index = {}
     for fn in (two_basic_blocks, if_else_blocks):
         if debug:
             print(fn.__name__)
             dis.dis(fn)
             print()
-        bb_mgr = basic_blocks(fn)
+        bb_mgr = basic_blocks(fn, offset2inst_index)
         cfg = ControlFlowGraph(bb_mgr)
         if debug:
             write_dot(fn.__name__, "/tmp/test_cfg-", cfg.graph, write_png=True)


### PR DESCRIPTION
Here we start to add all looping jumps and loop targets as pseudo-ops in `augment_disasm`. 

This is used in a not public yet decompiler for Python 3.9 (and above). 